### PR TITLE
カードの拡大表示機能を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.4",
+    "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.7.0",
     "jsdom": "^26.1.0",
     "oxlint": "^0.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^5.2.4
         version: 5.2.4(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1))(vue@3.5.16(typescript@5.8.3))
+      '@vue/test-utils':
+        specifier: ^2.4.6
+        version: 2.4.6
       '@vue/tsconfig':
         specifier: ^0.7.0
         version: 0.7.0(typescript@5.8.3)(vue@3.5.16(typescript@5.8.3))
@@ -253,6 +256,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -274,6 +281,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
   '@oxlint/darwin-arm64@0.18.0':
     resolution: {integrity: sha512-lJanO+V1JcV4QpfkFo/4L8qyjoL4jqSrOgA4bsf2JK0QH1w+bpQ4979dDF0HXsp1uJoyYVtkVuT8wP4C9TdJzg==}
@@ -314,6 +324,10 @@ packages:
     resolution: {integrity: sha512-gMxC4XrhnR5XRtjqhIvkPI1yyinwkSjp7VgeOTf4mDk0xwYROwg/mSWnKfDn7tXUKoWQLDsSfAp/SS8uSAQ9Bg==}
     cpu: [x64]
     os: [win32]
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@rollup/rollup-android-arm-eabi@4.42.0':
     resolution: {integrity: sha512-gldmAyS9hpj+H6LpRNlcjQWbuKUtb94lodB9uCz71Jm+7BxK1VIOo7y62tZZwxhA7j1ylv/yQz080L5WkS+LoQ==}
@@ -599,6 +613,9 @@ packages:
   '@vue/shared@3.5.16':
     resolution: {integrity: sha512-c/0fWy3Jw6Z8L9FmTyYfkpM5zklnqqa9+a6dz3DvONRKW2NEbh46BP0FHuLFSWi2TnQEtp91Z6zOWNrU6QiyPg==}
 
+  '@vue/test-utils@2.4.6':
+    resolution: {integrity: sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==}
+
   '@vue/tsconfig@0.7.0':
     resolution: {integrity: sha512-ku2uNz5MaZ9IerPPUyOHzyjhXoX2kVJaVf7hL315DC17vS6IiZRmmCPfggNbU16QTvM80+uYYy3eYJB59WCtvg==}
     peerDependencies:
@@ -610,12 +627,32 @@ packages:
       vue:
         optional: true
 
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
 
   alien-signals@1.0.13:
     resolution: {integrity: sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -646,6 +683,24 @@ packages:
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
 
   css-line-break@2.1.0:
     resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
@@ -683,6 +738,20 @@ packages:
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  editorconfig@1.0.4:
+    resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   enhanced-resolve@5.18.1:
     resolution: {integrity: sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==}
@@ -722,10 +791,18 @@ packages:
       picomatch:
         optional: true
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -754,12 +831,34 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@2.4.2:
     resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
     hasBin: true
+
+  js-beautify@1.15.4:
+    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
 
   jsdom@26.1.0:
     resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
@@ -843,6 +942,10 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  minimatch@9.0.1:
+    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -875,6 +978,11 @@ packages:
     resolution: {integrity: sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==}
     engines: {node: '>=18'}
 
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   nwsapi@2.2.20:
     resolution: {integrity: sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA==}
 
@@ -883,11 +991,22 @@ packages:
     engines: {node: '>=8.*'}
     hasBin: true
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -906,6 +1025,9 @@ packages:
   postcss@8.5.4:
     resolution: {integrity: sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==}
     engines: {node: ^10 || ^12 || >=14}
+
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -926,8 +1048,25 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -938,6 +1077,22 @@ packages:
 
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -1077,6 +1232,9 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  vue-component-type-helpers@2.2.10:
+    resolution: {integrity: sha512-iDUO7uQK+Sab2tYuiP9D1oLujCWlhHELHMgV/cB13cuGbG4qwkLHvtfWb6FzvxrIOPDnU0oHsz2MlQjhYDeaHA==}
+
   vue-tsc@2.2.10:
     resolution: {integrity: sha512-jWZ1xSaNbabEV3whpIDMbjVSVawjAyW+x1n3JeGQo7S0uv2n9F/JMgWW90tGWNFRKya4YwKMZgCtr0vRAM7DeQ==}
     hasBin: true
@@ -1111,10 +1269,23 @@ packages:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   ws@8.18.2:
     resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
@@ -1262,6 +1433,15 @@ snapshots:
   '@esbuild/win32-x64@0.25.5':
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.2
@@ -1282,6 +1462,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@one-ini/wasm@0.1.1': {}
 
   '@oxlint/darwin-arm64@0.18.0':
     optional: true
@@ -1305,6 +1487,9 @@ snapshots:
     optional: true
 
   '@oxlint/win32-x64@0.18.0':
+    optional: true
+
+  '@pkgjs/parseargs@0.11.0':
     optional: true
 
   '@rollup/rollup-android-arm-eabi@4.42.0':
@@ -1576,14 +1761,31 @@ snapshots:
 
   '@vue/shared@3.5.16': {}
 
+  '@vue/test-utils@2.4.6':
+    dependencies:
+      js-beautify: 1.15.4
+      vue-component-type-helpers: 2.2.10
+
   '@vue/tsconfig@0.7.0(typescript@5.8.3)(vue@3.5.16(typescript@5.8.3))':
     optionalDependencies:
       typescript: 5.8.3
       vue: 3.5.16(typescript@5.8.3)
 
+  abbrev@2.0.0: {}
+
   agent-base@7.1.3: {}
 
   alien-signals@1.0.13: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.1.0: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.1: {}
 
   assertion-error@2.0.1: {}
 
@@ -1608,6 +1810,25 @@ snapshots:
   check-error@2.1.1: {}
 
   chownr@3.0.0: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@10.0.1: {}
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
 
   css-line-break@2.1.0:
     dependencies:
@@ -1636,6 +1857,19 @@ snapshots:
   deep-eql@5.0.2: {}
 
   detect-libc@2.0.4: {}
+
+  eastasianwidth@0.2.0: {}
+
+  editorconfig@1.0.4:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.1
+      semver: 7.7.2
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   enhanced-resolve@5.18.1:
     dependencies:
@@ -1688,8 +1922,22 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fsevents@2.3.3:
     optional: true
+
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
 
   graceful-fs@4.2.11: {}
 
@@ -1722,9 +1970,31 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ini@1.3.8: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
   is-potential-custom-element-name@1.0.1: {}
 
+  isexe@2.0.0: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jiti@2.4.2: {}
+
+  js-beautify@1.15.4:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.4
+      glob: 10.4.5
+      js-cookie: 3.0.5
+      nopt: 7.2.1
+
+  js-cookie@3.0.5: {}
 
   jsdom@26.1.0:
     dependencies:
@@ -1806,6 +2076,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  minimatch@9.0.1:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
@@ -1828,6 +2102,10 @@ snapshots:
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu': 4.42.0
 
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
+
   nwsapi@2.2.20: {}
 
   oxlint@0.18.0:
@@ -1841,11 +2119,20 @@ snapshots:
       '@oxlint/win32-arm64': 0.18.0
       '@oxlint/win32-x64': 0.18.0
 
+  package-json-from-dist@1.0.1: {}
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
 
   path-browserify@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
 
   pathe@2.0.3: {}
 
@@ -1860,6 +2147,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  proto-list@1.2.4: {}
 
   punycode@2.3.1: {}
 
@@ -1897,13 +2186,43 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
+  semver@7.7.2: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
 
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
 
   std-env@3.9.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.1.0
 
   symbol-tree@3.2.4: {}
 
@@ -2036,6 +2355,8 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  vue-component-type-helpers@2.2.10: {}
+
   vue-tsc@2.2.10(typescript@5.8.3):
     dependencies:
       '@volar/typescript': 2.4.14
@@ -2069,10 +2390,26 @@ snapshots:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
 
   ws@8.18.2: {}
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -71,51 +71,55 @@ const {
 onMounted(initializeApp);
 
 // モーダルの状態
-const isImageModalVisible = ref(false);
-const selectedCardImage = ref<string | null>(null);
-const selectedCard = ref<Card | null>(null);
-const selectedCardIndex = ref<number | null>(null);
+const imageModalState = ref({
+  isVisible: false,
+  selectedCard: null as Card | null,
+  selectedImage: null as string | null,
+  selectedIndex: null as number | null,
+});
 
 // カード画像を拡大表示
 const openImageModal = (cardId: string) => {
-  const deckCard = sortedDeckCards.value.find(
+  // 単一の検索で deckCard と index を同時に取得
+  const cardIndex = sortedDeckCards.value.findIndex(
     (item) => item.card.id === cardId
   );
-  if (deckCard) {
-    const cardIndex = sortedDeckCards.value.findIndex(
-      (item) => item.card.id === cardId
-    );
-    selectedCard.value = deckCard.card;
-    selectedCardIndex.value = cardIndex;
-    selectedCardImage.value = getCardImageUrlSafe(cardId);
-    isImageModalVisible.value = true;
+
+  if (cardIndex !== -1) {
+    const deckCard = sortedDeckCards.value[cardIndex];
+    imageModalState.value.selectedCard = deckCard.card;
+    imageModalState.value.selectedIndex = cardIndex;
+    imageModalState.value.selectedImage = getCardImageUrlSafe(cardId);
+    imageModalState.value.isVisible = true;
   }
 };
 
 // モーダルを閉じる
 const closeImageModal = () => {
-  isImageModalVisible.value = false;
-  selectedCardImage.value = null;
-  selectedCard.value = null;
-  selectedCardIndex.value = null;
+  imageModalState.value.isVisible = false;
+  imageModalState.value.selectedImage = null;
+  imageModalState.value.selectedCard = null;
+  imageModalState.value.selectedIndex = null;
 };
 
 // カードナビゲーション
 const handleCardNavigation = (direction: "previous" | "next") => {
-  if (selectedCardIndex.value === null) return;
+  if (imageModalState.value.selectedIndex === null) return;
 
   let newIndex: number;
   if (direction === "previous") {
-    newIndex = selectedCardIndex.value - 1;
+    newIndex = imageModalState.value.selectedIndex - 1;
   } else {
-    newIndex = selectedCardIndex.value + 1;
+    newIndex = imageModalState.value.selectedIndex + 1;
   }
 
   if (newIndex >= 0 && newIndex < sortedDeckCards.value.length) {
     const newDeckCard = sortedDeckCards.value[newIndex];
-    selectedCard.value = newDeckCard.card;
-    selectedCardIndex.value = newIndex;
-    selectedCardImage.value = getCardImageUrlSafe(newDeckCard.card.id);
+    imageModalState.value.selectedCard = newDeckCard.card;
+    imageModalState.value.selectedIndex = newIndex;
+    imageModalState.value.selectedImage = getCardImageUrlSafe(
+      newDeckCard.card.id
+    );
   }
 };
 </script>
@@ -205,10 +209,10 @@ const handleCardNavigation = (direction: "previous" | "next") => {
 
     <!-- カード画像拡大モーダル -->
     <CardImageModal
-      :is-visible="isImageModalVisible"
-      :image-src="selectedCardImage"
-      :current-card="selectedCard"
-      :card-index="selectedCardIndex"
+      :is-visible="imageModalState.isVisible"
+      :image-src="imageModalState.selectedImage"
+      :current-card="imageModalState.selectedCard"
+      :card-index="imageModalState.selectedIndex"
       :total-cards="sortedDeckCards.length"
       @close="closeImageModal"
       @navigate="handleCardNavigation"

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,6 +5,7 @@ export { default as DeckSection } from "./layout/DeckSection.vue";
 export { default as ToastContainer } from "./layout/ToastContainer.vue";
 
 // Modal Components
+export { default as CardImageModal } from "./modals/CardImageModal.vue";
 export { default as ConfirmModal } from "./modals/ConfirmModal.vue";
 export { default as DeckCodeModal } from "./modals/DeckCodeModal.vue";
 export { default as FilterModal } from "./modals/FilterModal.vue";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,7 +5,7 @@ export { default as DeckSection } from "./layout/DeckSection.vue";
 export { default as ToastContainer } from "./layout/ToastContainer.vue";
 
 // Modal Components
-export { default as CardImageModal } from "./modals/CardImageModal.vue";
+// CardImageModal は動的インポートのみを使用するため、ここではエクスポートしない
 export { default as ConfirmModal } from "./modals/ConfirmModal.vue";
 export { default as DeckCodeModal } from "./modals/DeckCodeModal.vue";
 export { default as FilterModal } from "./modals/FilterModal.vue";

--- a/src/components/layout/DeckSection.vue
+++ b/src/components/layout/DeckSection.vue
@@ -2,7 +2,6 @@
 import { computed, ref } from "vue";
 import type { DeckCard } from "../../types";
 import DeckExportContainer from "./DeckExportContainer.vue";
-import CardImageModal from "../modals/CardImageModal.vue";
 import { handleImageError } from "../../utils/image";
 import { getCardImageUrlSafe } from "../../utils/imageHelpers";
 import { useLongPress } from "../../composables/useLongPress";
@@ -23,6 +22,7 @@ interface Emits {
   (e: "resetDeck"): void;
   (e: "incrementCardCount", cardId: string): void;
   (e: "decrementCardCount", cardId: string): void;
+  (e: "openImageModal", cardId: string): void;
 }
 
 defineProps<Props>();
@@ -36,20 +36,9 @@ const exportContainer = computed(
   () => deckExportContainerRef.value?.exportContainer || null
 );
 
-// モーダルの状態
-const isImageModalVisible = ref(false);
-const selectedCardImage = ref<string | null>(null);
-
 // カード画像を拡大表示
 const openImageModal = (cardId: string) => {
-  selectedCardImage.value = getCardImageUrlSafe(cardId);
-  isImageModalVisible.value = true;
-};
-
-// モーダルを閉じる
-const closeImageModal = () => {
-  isImageModalVisible.value = false;
-  selectedCardImage.value = null;
+  emit("openImageModal", cardId);
 };
 
 // 長押し機能の設定（デッキカード用）
@@ -79,7 +68,7 @@ defineExpose({
 
 <template>
   <div
-    class="flex flex-col flex-grow-0 h-1/2 p-1 sm:p-2 border-b border-slate-700/50 overflow-hidden relative z-10 backdrop-blur-sm"
+    class="flex flex-col flex-grow-0 h-1/2 p-1 sm:p-2 border-b border-slate-700/50 relative z-10 backdrop-blur-sm"
   >
     <!-- デッキ名入力 (モバイル優先) -->
     <div class="mb-1 px-1">
@@ -374,13 +363,6 @@ defineExpose({
       :deck-cards="deckCards"
       :sorted-deck-cards="sortedDeckCards"
       :is-saving="isSaving"
-    />
-
-    <!-- カード画像拡大モーダル -->
-    <CardImageModal
-      :is-visible="isImageModalVisible"
-      :image-src="selectedCardImage"
-      @close="closeImageModal"
     />
   </div>
 </template>

--- a/src/components/layout/DeckSection.vue
+++ b/src/components/layout/DeckSection.vue
@@ -25,7 +25,7 @@ interface Emits {
   (e: "openImageModal", cardId: string): void;
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
 const emit = defineEmits<Emits>();
 
 const deckExportContainerRef = ref<InstanceType<
@@ -61,6 +61,35 @@ const getDeckCardLongPressHandler = (cardId: string) => {
   return deckCardLongPressHandlers.get(cardId)!;
 };
 
+// ハンドラーのクリーンアップ機能
+const cleanupCardHandler = (cardId: string) => {
+  deckCardLongPressHandlers.delete(cardId);
+};
+
+// 全てのハンドラーをクリーンアップ
+const cleanupAllHandlers = () => {
+  deckCardLongPressHandlers.clear();
+};
+
+// カードデクリメント時にクリーンアップも実行
+const handleDecrementCard = (cardId: string) => {
+  // 現在のカードの情報を取得
+  const currentCard = props.deckCards.find((card) => card.card.id === cardId);
+
+  // カウントが1の場合、デクリメント後に削除されるためハンドラーもクリーンアップ
+  if (currentCard && currentCard.count === 1) {
+    cleanupCardHandler(cardId);
+  }
+
+  emit("decrementCardCount", cardId);
+};
+
+// デッキリセット時にクリーンアップも実行
+const handleResetDeck = () => {
+  cleanupAllHandlers();
+  emit("resetDeck");
+};
+
 defineExpose({
   exportContainer,
 });
@@ -81,7 +110,7 @@ defineExpose({
         <input
           id="deckName"
           type="text"
-          :value="deckName"
+          :value="props.deckName"
           @input="
             emit('updateDeckName', ($event.target as HTMLInputElement).value)
           "
@@ -95,12 +124,12 @@ defineExpose({
     <div class="flex flex-wrap gap-1 mb-1 px-1">
       <button
         @click="emit('generateDeckCode')"
-        :disabled="isGeneratingCode"
+        :disabled="props.isGeneratingCode"
         class="group relative flex-1 min-w-0 px-1 sm:px-2 py-0.5 sm:py-1 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded text-xs font-medium hover:from-blue-700 hover:to-blue-800 disabled:from-slate-600 disabled:to-slate-700 disabled:cursor-not-allowed transition-all duration-200 shadow-lg hover:shadow-blue-500/25"
         title="デッキコードの入出力"
       >
         <span
-          v-if="!isGeneratingCode"
+          v-if="!props.isGeneratingCode"
           class="flex items-center justify-center gap-1"
         >
           <svg
@@ -141,11 +170,14 @@ defineExpose({
 
       <button
         @click="emit('saveDeckAsPng')"
-        :disabled="deckCards.length === 0 || isSaving"
+        :disabled="props.deckCards.length === 0 || props.isSaving"
         class="group relative flex-1 min-w-0 px-1 sm:px-2 py-0.5 sm:py-1 bg-gradient-to-r from-emerald-600 to-emerald-700 text-white rounded text-xs font-medium hover:from-emerald-700 hover:to-emerald-800 disabled:from-slate-600 disabled:to-slate-700 disabled:cursor-not-allowed transition-all duration-200 shadow-lg hover:shadow-emerald-500/25"
         title="デッキ画像を保存"
       >
-        <span v-if="!isSaving" class="flex items-center justify-center gap-1">
+        <span
+          v-if="!props.isSaving"
+          class="flex items-center justify-center gap-1"
+        >
           <svg
             class="w-3 h-3"
             fill="none"
@@ -183,8 +215,8 @@ defineExpose({
       </button>
 
       <button
-        @click="emit('resetDeck')"
-        :disabled="deckCards.length === 0"
+        @click="handleResetDeck"
+        :disabled="props.deckCards.length === 0"
         class="group relative flex-1 min-w-0 px-1 sm:px-2 py-0.5 sm:py-1 bg-gradient-to-r from-red-600 to-red-700 text-white rounded text-xs font-medium hover:from-red-700 hover:to-red-800 disabled:from-slate-600 disabled:to-slate-700 disabled:cursor-not-allowed transition-all duration-200 shadow-lg hover:shadow-red-500/25"
         title="デッキをリセット"
       >
@@ -217,27 +249,27 @@ defineExpose({
         <span
           class="text-sm font-bold"
           :class="[
-            totalDeckCards === 60
+            props.totalDeckCards === 60
               ? 'text-green-400'
-              : totalDeckCards > 50
+              : props.totalDeckCards > 50
               ? 'text-yellow-400'
               : 'text-slate-100',
           ]"
         >
-          {{ totalDeckCards }}
+          {{ props.totalDeckCards }}
         </span>
         <span class="text-xs text-slate-400">/ 60</span>
         <div class="w-12 sm:w-16 h-1 bg-slate-700 rounded-full overflow-hidden">
           <div
             class="h-full transition-all duration-300 rounded-full"
             :class="[
-              totalDeckCards === 60
+              props.totalDeckCards === 60
                 ? 'bg-green-500'
-                : totalDeckCards > 50
+                : props.totalDeckCards > 50
                 ? 'bg-yellow-500'
                 : 'bg-blue-500',
             ]"
-            :style="{ width: `${(totalDeckCards / 60) * 100}%` }"
+            :style="{ width: `${(props.totalDeckCards / 60) * 100}%` }"
           ></div>
         </div>
       </div>
@@ -249,7 +281,7 @@ defineExpose({
       class="flex-grow overflow-y-auto grid grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2 md:gap-3 lg:gap-4 p-1 sm:p-2 bg-slate-800/40 backdrop-blur-sm rounded border border-slate-700/50 shadow-xl"
     >
       <div
-        v-for="item in sortedDeckCards"
+        v-for="item in props.sortedDeckCards"
         :key="item.card.id"
         class="group flex flex-col items-center relative h-fit transition-all duration-200"
       >
@@ -258,9 +290,13 @@ defineExpose({
           @mousedown="getDeckCardLongPressHandler(item.card.id).startPress"
           @mouseup="getDeckCardLongPressHandler(item.card.id).endPress"
           @mouseleave="getDeckCardLongPressHandler(item.card.id).cancelPress"
-          @touchstart="getDeckCardLongPressHandler(item.card.id).startPress"
-          @touchend="getDeckCardLongPressHandler(item.card.id).endPress"
-          @touchcancel="getDeckCardLongPressHandler(item.card.id).cancelPress"
+          @touchstart.passive="
+            getDeckCardLongPressHandler(item.card.id).startPress
+          "
+          @touchend.passive="getDeckCardLongPressHandler(item.card.id).endPress"
+          @touchcancel.passive="
+            getDeckCardLongPressHandler(item.card.id).cancelPress
+          "
           @contextmenu.prevent
           title="長押し: 拡大表示"
         >
@@ -280,7 +316,7 @@ defineExpose({
           class="absolute bottom-2 w-full px-1 flex items-center justify-center gap-1"
         >
           <button
-            @click="emit('decrementCardCount', item.card.id)"
+            @click="handleDecrementCard(item.card.id)"
             class="w-6 h-6 sm:w-8 sm:h-8 bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 text-white rounded-full flex items-center justify-center leading-none transition-all duration-200 shadow-lg hover:shadow-red-500/25"
           >
             <svg
@@ -305,7 +341,7 @@ defineExpose({
           <button
             @click="emit('incrementCardCount', item.card.id)"
             class="w-6 h-6 sm:w-8 sm:h-8 bg-gradient-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 text-white rounded-full flex items-center justify-center leading-none transition-all duration-200 shadow-lg hover:shadow-emerald-500/25 disabled:from-slate-600 disabled:to-slate-700 disabled:cursor-not-allowed"
-            :disabled="item.count >= 4 || totalDeckCards >= 60"
+            :disabled="item.count >= 4 || props.totalDeckCards >= 60"
           >
             <svg
               class="w-3 h-3 sm:w-4 sm:h-4"
@@ -325,7 +361,7 @@ defineExpose({
       </div>
 
       <div
-        v-if="deckCards.length === 0"
+        v-if="props.deckCards.length === 0"
         class="col-span-full text-center mt-2 sm:mt-4"
       >
         <div class="flex flex-col items-center gap-1 sm:gap-2 p-2 sm:p-4">
@@ -359,10 +395,10 @@ defineExpose({
     <!-- エクスポート用の非表示コンテナ -->
     <DeckExportContainer
       ref="deckExportContainerRef"
-      :deck-name="deckName"
-      :deck-cards="deckCards"
-      :sorted-deck-cards="sortedDeckCards"
-      :is-saving="isSaving"
+      :deck-name="props.deckName"
+      :deck-cards="props.deckCards"
+      :sorted-deck-cards="props.sortedDeckCards"
+      :is-saving="props.isSaving"
     />
   </div>
 </template>

--- a/src/components/modals/CardImageModal.test.ts
+++ b/src/components/modals/CardImageModal.test.ts
@@ -1,12 +1,19 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import CardImageModal from "./CardImageModal.vue";
+import type { Card } from "../../types";
 
 describe("CardImageModal", () => {
-  beforeEach(() => {
-    // キーボードイベントリスナーをモック
-    vi.spyOn(document, "addEventListener");
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
+
+  const testCard: Card = {
+    id: "test-card-1",
+    name: "テストカード",
+    kind: "Song",
+    type: "赤",
+  };
 
   it("isVisibleがfalseの場合、モーダルが表示されない", () => {
     const wrapper = mount(CardImageModal, {
@@ -30,16 +37,20 @@ describe("CardImageModal", () => {
     expect(wrapper.find(".fixed.inset-0").exists()).toBe(true);
   });
 
-  it("×ボタンが表示されない", () => {
+  it("ナビゲーションボタンが表示されない", () => {
     const wrapper = mount(CardImageModal, {
       props: {
         isVisible: true,
         imageSrc: "test-image.jpg",
+        currentCard: testCard,
+        cardIndex: 1,
+        totalCards: 3,
       },
     });
 
-    const closeButton = wrapper.find("button");
-    expect(closeButton.exists()).toBe(false);
+    // ナビゲーションボタンは表示されない
+    const buttons = wrapper.findAll("button");
+    expect(buttons).toHaveLength(0);
   });
 
   it("モーダル背景（画面外）をクリックするとcloseイベントが発火される", async () => {
@@ -65,7 +76,7 @@ describe("CardImageModal", () => {
       },
     });
 
-    const imageContainer = wrapper.find(".relative.max-w-\\[98vw\\]");
+    const imageContainer = wrapper.find(".max-w-\\[98vw\\]");
     await imageContainer.trigger("click");
 
     expect(wrapper.emitted("close")).toBeFalsy();
@@ -97,29 +108,34 @@ describe("CardImageModal", () => {
     expect(images.length).toBe(0);
   });
 
-  it("imageSrcが変更されたとき、imageLoadedがリセットされる", async () => {
+  it("カード情報は表示されない", () => {
     const wrapper = mount(CardImageModal, {
       props: {
         isVisible: true,
-        imageSrc: "test-image1.jpg",
+        imageSrc: "test-image.jpg",
+        currentCard: testCard,
+        cardIndex: 1,
+        totalCards: 3,
       },
     });
 
-    // 最初の画像のロードをシミュレート（非表示の画像でloadイベントを発火）
-    const images = wrapper.findAll("img");
-    if (images.length > 0) {
-      await images[images.length - 1].trigger("load"); // 最後の画像（非表示の画像）
-    }
-    await wrapper.vm.$nextTick();
+    // カード名や位置情報は表示されない
+    expect(wrapper.text()).not.toContain("テストカード");
+    expect(wrapper.text()).not.toContain("2 / 3");
+  });
 
-    // ローディング表示が消えていることを確認
-    expect(wrapper.find(".animate-spin").exists()).toBe(false);
+  it("タッチイベントが適切に設定されている", () => {
+    const wrapper = mount(CardImageModal, {
+      props: {
+        isVisible: true,
+        imageSrc: "test-image.jpg",
+        currentCard: testCard,
+        cardIndex: 1,
+        totalCards: 3,
+      },
+    });
 
-    // imageSrcを変更
-    await wrapper.setProps({ imageSrc: "test-image2.jpg" });
-    await wrapper.vm.$nextTick();
-
-    // ローディング表示が再び表示されることを確認
-    expect(wrapper.find(".animate-spin").exists()).toBe(true);
+    const touchContainer = wrapper.find(".touch-pan-y");
+    expect(touchContainer.exists()).toBe(true);
   });
 });

--- a/src/components/modals/CardImageModal.test.ts
+++ b/src/components/modals/CardImageModal.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import CardImageModal from "./CardImageModal.vue";
+
+describe("CardImageModal", () => {
+  beforeEach(() => {
+    // キーボードイベントリスナーをモック
+    vi.spyOn(document, "addEventListener");
+  });
+
+  it("isVisibleがfalseの場合、モーダルが表示されない", () => {
+    const wrapper = mount(CardImageModal, {
+      props: {
+        isVisible: false,
+        imageSrc: "test-image.jpg",
+      },
+    });
+
+    expect(wrapper.find(".fixed.inset-0").exists()).toBe(false);
+  });
+
+  it("isVisibleがtrueの場合、モーダルが表示される", () => {
+    const wrapper = mount(CardImageModal, {
+      props: {
+        isVisible: true,
+        imageSrc: "test-image.jpg",
+      },
+    });
+
+    expect(wrapper.find(".fixed.inset-0").exists()).toBe(true);
+  });
+
+  it("×ボタンが表示されない", () => {
+    const wrapper = mount(CardImageModal, {
+      props: {
+        isVisible: true,
+        imageSrc: "test-image.jpg",
+      },
+    });
+
+    const closeButton = wrapper.find("button");
+    expect(closeButton.exists()).toBe(false);
+  });
+
+  it("モーダル背景（画面外）をクリックするとcloseイベントが発火される", async () => {
+    const wrapper = mount(CardImageModal, {
+      props: {
+        isVisible: true,
+        imageSrc: "test-image.jpg",
+      },
+    });
+
+    const modalBackground = wrapper.find(".fixed.inset-0");
+    await modalBackground.trigger("click");
+
+    expect(wrapper.emitted("close")).toBeTruthy();
+    expect(wrapper.emitted("close")).toHaveLength(1);
+  });
+
+  it("画像コンテナをクリックしてもcloseイベントが発火されない", async () => {
+    const wrapper = mount(CardImageModal, {
+      props: {
+        isVisible: true,
+        imageSrc: "test-image.jpg",
+      },
+    });
+
+    const imageContainer = wrapper.find(".relative.max-w-\\[98vw\\]");
+    await imageContainer.trigger("click");
+
+    expect(wrapper.emitted("close")).toBeFalsy();
+  });
+
+  it("画像が提供された場合、画像が表示される", () => {
+    const wrapper = mount(CardImageModal, {
+      props: {
+        isVisible: true,
+        imageSrc: "test-image.jpg",
+      },
+    });
+
+    const images = wrapper.findAll("img");
+    expect(images.length).toBeGreaterThan(0);
+    expect(images[0].attributes("src")).toBe("test-image.jpg");
+    expect(images[0].attributes("alt")).toBe("");
+  });
+
+  it("imageSrcがnullの場合、画像が表示されない", () => {
+    const wrapper = mount(CardImageModal, {
+      props: {
+        isVisible: true,
+        imageSrc: null,
+      },
+    });
+
+    const images = wrapper.findAll("img");
+    expect(images.length).toBe(0);
+  });
+
+  it("imageSrcが変更されたとき、imageLoadedがリセットされる", async () => {
+    const wrapper = mount(CardImageModal, {
+      props: {
+        isVisible: true,
+        imageSrc: "test-image1.jpg",
+      },
+    });
+
+    // 最初の画像のロードをシミュレート（非表示の画像でloadイベントを発火）
+    const images = wrapper.findAll("img");
+    if (images.length > 0) {
+      await images[images.length - 1].trigger("load"); // 最後の画像（非表示の画像）
+    }
+    await wrapper.vm.$nextTick();
+
+    // ローディング表示が消えていることを確認
+    expect(wrapper.find(".animate-spin").exists()).toBe(false);
+
+    // imageSrcを変更
+    await wrapper.setProps({ imageSrc: "test-image2.jpg" });
+    await wrapper.vm.$nextTick();
+
+    // ローディング表示が再び表示されることを確認
+    expect(wrapper.find(".animate-spin").exists()).toBe(true);
+  });
+});

--- a/src/components/modals/CardImageModal.vue
+++ b/src/components/modals/CardImageModal.vue
@@ -1,35 +1,129 @@
 <template>
   <div
     v-if="isVisible"
-    class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+    class="fixed inset-0 z-[9999] flex items-center justify-center bg-black/80 p-4"
     @click="closeModal"
   >
     <div class="max-w-[98vw] max-h-[98vh]" @click.stop>
-      <img
-        v-if="imageSrc"
-        :src="imageSrc"
-        alt=""
-        class="max-w-full max-h-full object-contain rounded-lg shadow-2xl"
-        @error="handleImageError"
-      />
+      <!-- カード画像 -->
+      <div
+        ref="imageContainer"
+        class="touch-pan-y"
+        @touchstart="handleTouchStart"
+        @touchmove="handleTouchMove"
+        @touchend="handleTouchEnd"
+      >
+        <img
+          v-if="imageSrc"
+          :src="imageSrc"
+          alt=""
+          class="max-w-full max-h-full object-contain rounded-lg shadow-2xl"
+          @error="handleImageError"
+        />
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref, computed } from "vue";
 import { handleImageError } from "../../utils/image";
+import type { Card } from "../../types";
 
 interface Props {
   isVisible: boolean;
   imageSrc: string | null;
+  currentCard?: Card | null;
+  cardIndex?: number | null;
+  totalCards?: number | null;
 }
 
 interface Emits {
   (e: "close"): void;
+  (e: "navigate", direction: "previous" | "next"): void;
 }
 
-defineProps<Props>();
+const props = defineProps<Props>();
 const emit = defineEmits<Emits>();
+
+const imageContainer = ref<HTMLElement | null>(null);
+
+// スワイプ関連の状態
+const touchStartX = ref<number | null>(null);
+const touchStartY = ref<number | null>(null);
+const minSwipeDistance = 50; // 最小スワイプ距離（px）
+
+// ナビゲーション可能性を計算
+const hasPreviousCard = computed(() => {
+  if (props.cardIndex === null || props.cardIndex === undefined) return false;
+  return props.cardIndex > 0;
+});
+
+const hasNextCard = computed(() => {
+  if (
+    props.cardIndex === null ||
+    props.cardIndex === undefined ||
+    props.totalCards === null ||
+    props.totalCards === undefined
+  )
+    return false;
+  return props.cardIndex < props.totalCards - 1;
+});
+
+// スワイプハンドラー
+const handleTouchStart = (event: TouchEvent) => {
+  if (event.touches.length === 1) {
+    touchStartX.value = event.touches[0].clientX;
+    touchStartY.value = event.touches[0].clientY;
+  }
+};
+
+const handleTouchMove = (event: TouchEvent) => {
+  // タッチムーブ中にデフォルトのスクロールを防ぐ
+  event.preventDefault();
+};
+
+const handleTouchEnd = (event: TouchEvent) => {
+  if (touchStartX.value === null || touchStartY.value === null) return;
+
+  const touch = event.changedTouches[0];
+  const deltaX = touch.clientX - touchStartX.value;
+  const deltaY = touch.clientY - touchStartY.value;
+
+  // 縦方向のスワイプが横方向よりも大きい場合は処理しない
+  if (Math.abs(deltaY) > Math.abs(deltaX)) {
+    touchStartX.value = null;
+    touchStartY.value = null;
+    return;
+  }
+
+  // 最小距離以上のスワイプかチェック
+  if (Math.abs(deltaX) >= minSwipeDistance) {
+    if (deltaX > 0 && hasPreviousCard.value) {
+      // 右スワイプ - 前のカード
+      navigateToPrevious();
+    } else if (deltaX < 0 && hasNextCard.value) {
+      // 左スワイプ - 次のカード
+      navigateToNext();
+    }
+  }
+
+  touchStartX.value = null;
+  touchStartY.value = null;
+};
+
+// ナビゲーション関数
+const navigateToPrevious = () => {
+  if (hasPreviousCard.value) {
+    emit("navigate", "previous");
+  }
+};
+
+const navigateToNext = () => {
+  if (hasNextCard.value) {
+    emit("navigate", "next");
+  }
+};
 
 const closeModal = () => {
   emit("close");

--- a/src/components/modals/CardImageModal.vue
+++ b/src/components/modals/CardImageModal.vue
@@ -1,0 +1,37 @@
+<template>
+  <div
+    v-if="isVisible"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+    @click="closeModal"
+  >
+    <div class="max-w-[98vw] max-h-[98vh]" @click.stop>
+      <img
+        v-if="imageSrc"
+        :src="imageSrc"
+        alt=""
+        class="max-w-full max-h-full object-contain rounded-lg shadow-2xl"
+        @error="handleImageError"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { handleImageError } from "../../utils/image";
+
+interface Props {
+  isVisible: boolean;
+  imageSrc: string | null;
+}
+
+interface Emits {
+  (e: "close"): void;
+}
+
+defineProps<Props>();
+const emit = defineEmits<Emits>();
+
+const closeModal = () => {
+  emit("close");
+};
+</script>

--- a/src/composables/useLongPress.test.ts
+++ b/src/composables/useLongPress.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { useLongPress } from "./useLongPress";
+
+describe("useLongPress", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("長押しコールバックが指定した時間後に呼ばれる", async () => {
+    const onLongPress = vi.fn();
+    const { startPress, endPress } = useLongPress({
+      delay: 500,
+      onLongPress,
+    });
+
+    const mockEvent = new Event("mousedown");
+    startPress(mockEvent);
+
+    // 500ms経過前は呼ばれない
+    vi.advanceTimersByTime(400);
+    expect(onLongPress).not.toHaveBeenCalled();
+
+    // 500ms経過後に呼ばれる
+    vi.advanceTimersByTime(100);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+
+    endPress();
+  });
+
+  it("短時間で終了した場合は通常のプレスコールバックが呼ばれる", () => {
+    const onLongPress = vi.fn();
+    const onPress = vi.fn();
+    const { startPress, endPress } = useLongPress({
+      delay: 500,
+      onLongPress,
+      onPress,
+    });
+
+    const mockEvent = new Event("mousedown");
+    startPress(mockEvent);
+
+    // 短時間で終了
+    vi.advanceTimersByTime(200);
+    endPress();
+
+    expect(onLongPress).not.toHaveBeenCalled();
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("キャンセルした場合はどちらのコールバックも呼ばれない", () => {
+    const onLongPress = vi.fn();
+    const onPress = vi.fn();
+    const { startPress, cancelPress } = useLongPress({
+      delay: 500,
+      onLongPress,
+      onPress,
+    });
+
+    const mockEvent = new Event("mousedown");
+    startPress(mockEvent);
+
+    vi.advanceTimersByTime(300);
+    cancelPress();
+
+    // さらに時間が経過しても呼ばれない
+    vi.advanceTimersByTime(300);
+    expect(onLongPress).not.toHaveBeenCalled();
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("長押し後に終了してもプレスコールバックは呼ばれない", () => {
+    const onLongPress = vi.fn();
+    const onPress = vi.fn();
+    const { startPress, endPress } = useLongPress({
+      delay: 500,
+      onLongPress,
+      onPress,
+    });
+
+    const mockEvent = new Event("mousedown");
+    startPress(mockEvent);
+
+    // 長押し時間経過
+    vi.advanceTimersByTime(500);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+
+    // 終了してもプレスコールバックは呼ばれない
+    endPress();
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it("デフォルトの長押し時間が500msに設定されている", () => {
+    const onLongPress = vi.fn();
+    const { startPress } = useLongPress({ onLongPress });
+
+    const mockEvent = new Event("mousedown");
+    startPress(mockEvent);
+
+    vi.advanceTimersByTime(499);
+    expect(onLongPress).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("イベントのpreventDefaultが呼ばれる", () => {
+    const { startPress } = useLongPress({});
+    const mockEvent = new Event("mousedown");
+    const preventDefaultSpy = vi.spyOn(mockEvent, "preventDefault");
+
+    startPress(mockEvent);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+});

--- a/src/composables/useLongPress.test.ts
+++ b/src/composables/useLongPress.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { defineComponent } from "vue";
+import { mount } from "@vue/test-utils";
 import { useLongPress } from "./useLongPress";
 
 describe("useLongPress", () => {
@@ -13,11 +15,21 @@ describe("useLongPress", () => {
 
   it("長押しコールバックが指定した時間後に呼ばれる", async () => {
     const onLongPress = vi.fn();
-    const { startPress, endPress } = useLongPress({
-      delay: 500,
-      onLongPress,
+    let composableResult: ReturnType<typeof useLongPress>;
+
+    const TestComponent = defineComponent({
+      setup() {
+        composableResult = useLongPress({
+          delay: 500,
+          onLongPress,
+        });
+        return composableResult;
+      },
+      template: "<div></div>",
     });
 
+    const wrapper = mount(TestComponent);
+    const { startPress, endPress } = composableResult!;
     const mockEvent = new Event("mousedown");
     startPress(mockEvent);
 
@@ -30,17 +42,28 @@ describe("useLongPress", () => {
     expect(onLongPress).toHaveBeenCalledTimes(1);
 
     endPress();
+    wrapper.unmount();
   });
 
-  it("短時間で終了した場合は通常のプレスコールバックが呼ばれる", () => {
+  it("短時間で終了した場合は通常のプレスコールバックが呼ばれる", async () => {
     const onLongPress = vi.fn();
     const onPress = vi.fn();
-    const { startPress, endPress } = useLongPress({
-      delay: 500,
-      onLongPress,
-      onPress,
+    let composableResult: ReturnType<typeof useLongPress>;
+
+    const TestComponent = defineComponent({
+      setup() {
+        composableResult = useLongPress({
+          delay: 500,
+          onLongPress,
+          onPress,
+        });
+        return composableResult;
+      },
+      template: "<div></div>",
     });
 
+    const wrapper = mount(TestComponent);
+    const { startPress, endPress } = composableResult!;
     const mockEvent = new Event("mousedown");
     startPress(mockEvent);
 
@@ -50,17 +73,28 @@ describe("useLongPress", () => {
 
     expect(onLongPress).not.toHaveBeenCalled();
     expect(onPress).toHaveBeenCalledTimes(1);
+    wrapper.unmount();
   });
 
-  it("キャンセルした場合はどちらのコールバックも呼ばれない", () => {
+  it("キャンセルした場合はどちらのコールバックも呼ばれない", async () => {
     const onLongPress = vi.fn();
     const onPress = vi.fn();
-    const { startPress, cancelPress } = useLongPress({
-      delay: 500,
-      onLongPress,
-      onPress,
+    let composableResult: ReturnType<typeof useLongPress>;
+
+    const TestComponent = defineComponent({
+      setup() {
+        composableResult = useLongPress({
+          delay: 500,
+          onLongPress,
+          onPress,
+        });
+        return composableResult;
+      },
+      template: "<div></div>",
     });
 
+    const wrapper = mount(TestComponent);
+    const { startPress, cancelPress } = composableResult!;
     const mockEvent = new Event("mousedown");
     startPress(mockEvent);
 
@@ -71,17 +105,28 @@ describe("useLongPress", () => {
     vi.advanceTimersByTime(300);
     expect(onLongPress).not.toHaveBeenCalled();
     expect(onPress).not.toHaveBeenCalled();
+    wrapper.unmount();
   });
 
-  it("長押し後に終了してもプレスコールバックは呼ばれない", () => {
+  it("長押し後に終了してもプレスコールバックは呼ばれない", async () => {
     const onLongPress = vi.fn();
     const onPress = vi.fn();
-    const { startPress, endPress } = useLongPress({
-      delay: 500,
-      onLongPress,
-      onPress,
+    let composableResult: ReturnType<typeof useLongPress>;
+
+    const TestComponent = defineComponent({
+      setup() {
+        composableResult = useLongPress({
+          delay: 500,
+          onLongPress,
+          onPress,
+        });
+        return composableResult;
+      },
+      template: "<div></div>",
     });
 
+    const wrapper = mount(TestComponent);
+    const { startPress, endPress } = composableResult!;
     const mockEvent = new Event("mousedown");
     startPress(mockEvent);
 
@@ -92,12 +137,23 @@ describe("useLongPress", () => {
     // 終了してもプレスコールバックは呼ばれない
     endPress();
     expect(onPress).not.toHaveBeenCalled();
+    wrapper.unmount();
   });
 
-  it("デフォルトの長押し時間が500msに設定されている", () => {
+  it("デフォルトの長押し時間が500msに設定されている", async () => {
     const onLongPress = vi.fn();
-    const { startPress } = useLongPress({ onLongPress });
+    let composableResult: ReturnType<typeof useLongPress>;
 
+    const TestComponent = defineComponent({
+      setup() {
+        composableResult = useLongPress({ onLongPress });
+        return composableResult;
+      },
+      template: "<div></div>",
+    });
+
+    const wrapper = mount(TestComponent);
+    const { startPress } = composableResult!;
     const mockEvent = new Event("mousedown");
     startPress(mockEvent);
 
@@ -106,15 +162,28 @@ describe("useLongPress", () => {
 
     vi.advanceTimersByTime(1);
     expect(onLongPress).toHaveBeenCalledTimes(1);
+    wrapper.unmount();
   });
 
-  it("イベントのpreventDefaultが呼ばれる", () => {
-    const { startPress } = useLongPress({});
-    const mockEvent = new Event("mousedown");
+  it("contextmenuイベントのpreventDefaultが呼ばれる", async () => {
+    let composableResult: ReturnType<typeof useLongPress>;
+
+    const TestComponent = defineComponent({
+      setup() {
+        composableResult = useLongPress({});
+        return composableResult;
+      },
+      template: "<div></div>",
+    });
+
+    const wrapper = mount(TestComponent);
+    const { startPress } = composableResult!;
+    const mockEvent = new Event("contextmenu");
     const preventDefaultSpy = vi.spyOn(mockEvent, "preventDefault");
 
     startPress(mockEvent);
 
     expect(preventDefaultSpy).toHaveBeenCalled();
+    wrapper.unmount();
   });
 });

--- a/src/composables/useLongPress.ts
+++ b/src/composables/useLongPress.ts
@@ -1,0 +1,61 @@
+import { ref, onBeforeUnmount } from "vue";
+
+export interface UseLongPressOptions {
+  delay?: number; // 長押しとみなす時間（ミリ秒）
+  onLongPress?: () => void; // 長押し時のコールバック
+  onPress?: () => void; // 通常のプレス時のコールバック
+}
+
+export function useLongPress(options: UseLongPressOptions = {}) {
+  const { delay = 500, onLongPress, onPress } = options;
+
+  let pressTimer: number | null = null;
+  let isLongPress = ref(false);
+
+  const startPress = (event: Event) => {
+    // デフォルトのコンテキストメニューを無効化
+    event.preventDefault();
+
+    isLongPress.value = false;
+    pressTimer = setTimeout(() => {
+      isLongPress.value = true;
+      onLongPress?.();
+    }, delay);
+  };
+
+  const endPress = () => {
+    if (pressTimer) {
+      clearTimeout(pressTimer);
+      pressTimer = null;
+    }
+
+    // 長押しでない場合は通常のプレスとして処理
+    if (!isLongPress.value && onPress) {
+      onPress();
+    }
+
+    isLongPress.value = false;
+  };
+
+  const cancelPress = () => {
+    if (pressTimer) {
+      clearTimeout(pressTimer);
+      pressTimer = null;
+    }
+    isLongPress.value = false;
+  };
+
+  // クリーンアップ
+  onBeforeUnmount(() => {
+    if (pressTimer) {
+      clearTimeout(pressTimer);
+    }
+  });
+
+  return {
+    startPress,
+    endPress,
+    cancelPress,
+    isLongPress,
+  };
+}

--- a/src/composables/useLongPress.ts
+++ b/src/composables/useLongPress.ts
@@ -7,14 +7,19 @@ export interface UseLongPressOptions {
 }
 
 export function useLongPress(options: UseLongPressOptions = {}) {
-  const { delay = 500, onLongPress, onPress } = options;
-
-  let pressTimer: number | null = null;
+  const {
+    delay = window.navigator.userAgent.includes("Mobile") ? 400 : 500,
+    onLongPress,
+    onPress,
+  } = options;
+  let pressTimer: ReturnType<typeof setTimeout> | null = null;
   let isLongPress = ref(false);
 
   const startPress = (event: Event) => {
-    // デフォルトのコンテキストメニューを無効化
-    event.preventDefault();
+    // デフォルトのコンテキストメニューを無効化（contextmenuイベントの場合のみ）
+    if (event.type === "contextmenu") {
+      event.preventDefault();
+    }
 
     isLongPress.value = false;
     pressTimer = setTimeout(() => {

--- a/src/constants/errorMessages.ts
+++ b/src/constants/errorMessages.ts
@@ -1,0 +1,11 @@
+/**
+ * エラーメッセージの定数定義
+ * 将来的な国際化対応を考慮した構造
+ */
+export const ERROR_MESSAGES = {
+  VALIDATION: {
+    BASE_MESSAGE_NOT_PROVIDED: "ベースメッセージが指定されていません",
+    OPERATION_NOT_PROVIDED: "操作が指定されていません",
+    ERROR_MESSAGE_NOT_PROVIDED: "エラーメッセージが指定されていません",
+  },
+} as const;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
 export * from "./export";
 export * from "./game";
 export * from "./storage";
+export * from "./errorMessages";

--- a/src/utils/errorHandler.test.ts
+++ b/src/utils/errorHandler.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { handleError, safeAsyncOperation } from "./errorHandler";
+import { ERROR_MESSAGES } from "../constants";
 
 describe("errorHandler", () => {
   describe("handleError", () => {
@@ -26,7 +27,9 @@ describe("errorHandler", () => {
         throw new Error("unreachable");
       }
 
-      expect(result.error.message).toBe("ベースメッセージが指定されていません");
+      expect(result.error.message).toBe(
+        ERROR_MESSAGES.VALIDATION.BASE_MESSAGE_NOT_PROVIDED
+      );
     });
 
     it("Error以外のエラーも処理できる", () => {
@@ -60,7 +63,9 @@ describe("errorHandler", () => {
         throw new Error("unreachable");
       }
 
-      expect(result.error.message).toBe("操作が指定されていません");
+      expect(result.error.message).toBe(
+        ERROR_MESSAGES.VALIDATION.OPERATION_NOT_PROVIDED
+      );
     });
 
     it("エラーメッセージが指定されていない場合にエラーを返す", async () => {
@@ -71,7 +76,9 @@ describe("errorHandler", () => {
         throw new Error("unreachable");
       }
 
-      expect(result.error.message).toBe("エラーメッセージが指定されていません");
+      expect(result.error.message).toBe(
+        ERROR_MESSAGES.VALIDATION.ERROR_MESSAGE_NOT_PROVIDED
+      );
     });
 
     it("非同期操作でエラーが発生した場合にエラーを返す", async () => {

--- a/src/utils/errorHandler.ts
+++ b/src/utils/errorHandler.ts
@@ -1,5 +1,6 @@
 import { ok, err, type Result } from "neverthrow";
 import { logger } from "./logger";
+import { ERROR_MESSAGES } from "../constants";
 
 /**
  * エラーを統一的に処理するヘルパー関数
@@ -13,7 +14,7 @@ export function handleError(
   showErrorFunc?: (message: string) => void
 ): Result<string, { message: string }> {
   if (!baseMessage) {
-    const errorMessage = "ベースメッセージが指定されていません";
+    const errorMessage = ERROR_MESSAGES.VALIDATION.BASE_MESSAGE_NOT_PROVIDED;
     logger.error(errorMessage, error);
     return err({ message: errorMessage });
   }
@@ -44,12 +45,15 @@ export async function safeAsyncOperation(
   showErrorFunc?: (message: string) => void
 ): Promise<Result<void, { message: string; originalError: unknown }>> {
   if (!operation) {
-    return err({ message: "操作が指定されていません", originalError: null });
+    return err({
+      message: ERROR_MESSAGES.VALIDATION.OPERATION_NOT_PROVIDED,
+      originalError: null,
+    });
   }
 
   if (!errorMessage) {
     return err({
-      message: "エラーメッセージが指定されていません",
+      message: ERROR_MESSAGES.VALIDATION.ERROR_MESSAGE_NOT_PROVIDED,
       originalError: null,
     });
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - カード画像を拡大表示するモーダルを追加し、長押し操作で画像を開いて左右スワイプやキーボードでカード間を移動可能にしました。
  - カードリストやデッキ内のカード画像に長押し対応を追加し、短押しでカード追加、長押しで拡大表示ができるようになりました。
  - 長押し操作を扱う新しい機能を導入しました。

- **バグ修正**
  - エラーハンドリングを改善し、エラー発生時のメッセージ表示が統一かつ明確になりました。

- **テスト**
  - カード画像モーダルと長押し操作機能の包括的なテストを追加しました。

- **その他**
  - 開発用パッケージの追加と定数の整理を行いました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->