### PR TITLE
デッキ画像のデッキ名フォントサイズが小さくならないよう固定

### DIFF
--- a/src/constants/export.ts
+++ b/src/constants/export.ts
@@ -8,7 +8,7 @@ export const EXPORT_CONFIG: ExportConfig = {
     padding: "0 40px 10px",
   },
   deckName: {
-    fontSize: "clamp(48px, 4.2vw, 80px)",
+    fontSize: "80px",
     fontWeight: "bold",
     color: "#f9fafb",
     fontFamily: "serif, sans-serif",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - デッキ名のフォントサイズが固定値（80px）に変更され、表示が一貫するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->