### PR TITLE
デッキコードメニューの改善

### DIFF
--- a/src/components/modals/DeckCodeModal.vue
+++ b/src/components/modals/DeckCodeModal.vue
@@ -67,6 +67,7 @@ const emit = defineEmits<Emits>();
                 ($event.target as HTMLInputElement).value
               )
             "
+            @contextmenu="$event.stopPropagation()"
             class="flex-grow px-3 py-2 text-sm sm:text-base rounded bg-gray-700 border border-gray-600 focus:outline-none focus:ring focus:border-blue-500"
             placeholder="デッキコードを入力"
           />

--- a/src/components/modals/DeckCodeModal.vue
+++ b/src/components/modals/DeckCodeModal.vue
@@ -67,7 +67,7 @@ const emit = defineEmits<Emits>();
                 ($event.target as HTMLInputElement).value
               )
             "
-            @contextmenu="$event.stopPropagation()"
+            @contextmenu.stop
             class="flex-grow px-3 py-2 text-sm sm:text-base rounded bg-gray-700 border border-gray-600 focus:outline-none focus:ring focus:border-blue-500"
             placeholder="デッキコードを入力"
           />

--- a/src/components/modals/DeckCodeModal.vue
+++ b/src/components/modals/DeckCodeModal.vue
@@ -46,7 +46,7 @@ const emit = defineEmits<Emits>();
           />
           <button
             @click="emit('copyCode')"
-            class="px-3 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 transition duration-200 whitespace-nowrap"
+            class="px-3 py-2 bg-blue-600 text-white rounded text-sm hover:bg-blue-700 transition duration-200 whitespace-nowrap min-w-24"
           >
             コピー
           </button>
@@ -73,7 +73,7 @@ const emit = defineEmits<Emits>();
           />
           <button
             @click="emit('importCode')"
-            class="px-3 py-2 bg-green-600 text-white rounded text-sm hover:bg-green-700 transition duration-200 whitespace-nowrap"
+            class="px-3 py-2 bg-green-600 text-white rounded text-sm hover:bg-green-700 transition duration-200 whitespace-nowrap min-w-24"
           >
             インポート
           </button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **スタイル**
  - 「コピー」と「インポート」ボタンに最小幅を追加し、ボタンのサイズを統一しました。

- **バグ修正**
  - デッキコード入力欄での右クリック時に、不要なコンテキストメニューイベントの伝播を防止しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->