### PR TITLE
デッキ上限枚数の撤廃と増減ボタンの不具合を修正

### DIFF
--- a/src/components/layout/CardListSection.vue
+++ b/src/components/layout/CardListSection.vue
@@ -114,9 +114,10 @@ const getLongPressHandler = (card: Card, index: number) => {
         delay: 500, // 500msで長押し判定
         onLongPress: () => openImageModal(card, index),
         onPress: () => {
-          if (getCardInDeck(card.id) === 0) {
+          const current = getCardInDeck(card.id);
+          if (current === 0) {
             emit("addCard", card);
-          } else {
+          } else if (current < 4) {
             emit("incrementCard", card.id);
           }
         },

--- a/src/components/layout/CardListSection.vue
+++ b/src/components/layout/CardListSection.vue
@@ -113,7 +113,13 @@ const getLongPressHandler = (card: Card, index: number) => {
       useLongPress({
         delay: 500, // 500msで長押し判定
         onLongPress: () => openImageModal(card, index),
-        onPress: () => emit("addCard", card),
+        onPress: () => {
+          if (getCardInDeck(card.id) === 0) {
+            emit("addCard", card);
+          } else {
+            emit("incrementCard", card.id);
+          }
+        },
       })
     );
   }

--- a/src/components/layout/DeckSection.vue
+++ b/src/components/layout/DeckSection.vue
@@ -36,7 +36,6 @@ const exportStore = useExportStore();
 
 // デッキ操作のコンポーザブル
 const {
-  deckState,
   incrementCardCount: handleIncrementCard,
   decrementCardCount: handleDecrementCard,
 } = useDeckOperations();
@@ -321,15 +320,6 @@ defineExpose({
           {{ totalDeckCards }}
         </span>
         <span class="text-xs text-slate-400">/ 60</span>
-
-        <!-- デッキ状態インジケーター -->
-        <div
-          v-if="!deckState.isValid"
-          class="ml-1 text-xs text-red-400"
-          :title="deckState.validationErrors.join(', ')"
-        >
-          ⚠️
-        </div>
 
         <div class="w-12 sm:w-16 h-1 bg-slate-700 rounded-full overflow-hidden">
           <div

--- a/src/domain/deck.ts
+++ b/src/domain/deck.ts
@@ -189,11 +189,9 @@ export const incrementCardCount = (
   cards: readonly DeckCard[],
   cardId: string
 ): Result<readonly DeckCard[], DeckOperationError> => {
-  return setCardCount(
-    cards,
-    cardId,
-    (cards.find((dc) => dc.card.id === cardId)?.count || 0) + 1
-  );
+  const deckMap = createDeckCardMap(cards);
+  const current = deckMap.get(cardId)?.count ?? 0;
+  return setCardCount(cards, cardId, current + 1);
 };
 
 // カード枚数を減らす（Mapベース最適化版）
@@ -201,11 +199,9 @@ export const decrementCardCount = (
   cards: readonly DeckCard[],
   cardId: string
 ): Result<readonly DeckCard[], DeckOperationError> => {
-  return setCardCount(
-    cards,
-    cardId,
-    (cards.find((dc) => dc.card.id === cardId)?.count || 0) - 1
-  );
+  const deckMap = createDeckCardMap(cards);
+  const current = deckMap.get(cardId)?.count ?? 0;
+  return setCardCount(cards, cardId, current - 1);
 };
 
 // デッキ操作を実行

--- a/src/domain/deck.ts
+++ b/src/domain/deck.ts
@@ -9,7 +9,6 @@ import type {
 
 // ドメイン定数
 const MAX_CARD_COPIES = 4;
-const MAX_DECK_SIZE = 60;
 
 // =============================================================================
 // Map ベースのパフォーマンス最適化関数
@@ -43,20 +42,6 @@ const calculateTotalCardsFromMap = (map: Map<string, DeckCard>): number => {
 // =============================================================================
 // ヘルパー関数
 // =============================================================================
-
-// デッキサイズ超過チェック
-const checkDeckSizeExceeded = (
-  totalCount: number
-): Result<void, DeckOperationError> => {
-  if (totalCount > MAX_DECK_SIZE) {
-    return err({
-      type: "deckSizeExceeded",
-      currentSize: totalCount,
-      maxSize: MAX_DECK_SIZE,
-    });
-  }
-  return ok(undefined);
-};
 
 // =============================================================================
 // 公開API関数（既存APIとの互換性を保持）
@@ -110,13 +95,6 @@ export const calculateDeckState = (cards: readonly DeckCard[]): DeckState => {
     }
   }
 
-  // デッキサイズのバリデーション
-  if (totalCount > MAX_DECK_SIZE) {
-    errors.push(
-      `デッキサイズが上限を超えています: ${totalCount}/${MAX_DECK_SIZE}`
-    );
-  }
-
   if (errors.length > 0) {
     return { type: "invalid", cards, totalCount, errors };
   }
@@ -147,20 +125,8 @@ export const addCardToDeck = (
     };
     deckMap.set(cardToAdd.id, updatedCard);
 
-    const totalCount = calculateTotalCardsFromMap(deckMap);
-    const sizeCheckResult = checkDeckSizeExceeded(totalCount);
-    if (sizeCheckResult.isErr()) {
-      return err(sizeCheckResult.error);
-    }
-
     return ok(mapToDeckCards(deckMap));
   } else {
-    const totalCount = calculateTotalCardsFromMap(deckMap) + 1;
-    const sizeCheckResult = checkDeckSizeExceeded(totalCount);
-    if (sizeCheckResult.isErr()) {
-      return err(sizeCheckResult.error);
-    }
-
     const newDeckCardResult = createDeckCard(cardToAdd, 1);
     if (newDeckCardResult.isErr()) {
       return err(newDeckCardResult.error);
@@ -199,12 +165,6 @@ export const setCardCount = (
 
   const updatedCard = { ...existingCard, count };
   deckMap.set(cardId, updatedCard);
-
-  const totalCount = calculateTotalCardsFromMap(deckMap);
-  const sizeCheckResult = checkDeckSizeExceeded(totalCount);
-  if (sizeCheckResult.isErr()) {
-    return err(sizeCheckResult.error);
-  }
 
   return ok(mapToDeckCards(deckMap));
 };

--- a/src/domain/deck.ts
+++ b/src/domain/deck.ts
@@ -30,15 +30,6 @@ const mapToDeckCards = (map: Map<string, DeckCard>): readonly DeckCard[] => {
   return Array.from(map.values());
 };
 
-// Mapを使用した合計カード枚数計算
-const calculateTotalCardsFromMap = (map: Map<string, DeckCard>): number => {
-  let sum = 0;
-  for (const deckCard of map.values()) {
-    sum += deckCard.count;
-  }
-  return sum;
-};
-
 // =============================================================================
 // ヘルパー関数
 // =============================================================================
@@ -66,12 +57,11 @@ export const createDeckCard = (
   return ok({ card, count });
 };
 
-// デッキの合計カード枚数を計算
 export const calculateTotalCards = (cards: readonly DeckCard[]): number => {
-  const deckMap = createDeckCardMap(cards);
-  return calculateTotalCardsFromMap(deckMap);
+  let sum = 0;
+  for (const c of cards) sum += c.count;
+  return sum;
 };
-
 // デッキの状態を計算
 export const calculateDeckState = (cards: readonly DeckCard[]): DeckState => {
   if (cards.length === 0) {

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -14,9 +14,8 @@ export const isCardMatchingText = (card: Card, textLower: string): boolean => {
 
   // タグでの検索
   if (card.tags) {
-    return card.tags.some((tag: string) =>
-      tag.toLowerCase().includes(textLower)
-    );
+    const tags = Array.isArray(card.tags) ? card.tags : [card.tags];
+    return tags.some((tag: string) => tag.toLowerCase().includes(textLower));
   }
 
   return false;

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,5 +1,4 @@
 import type { Card, CardType } from "../types/card";
-import type { FilterCriteria } from "../types/filter";
 
 /**
  * カードがテキスト検索にマッチするかチェック
@@ -13,17 +12,11 @@ export const isCardMatchingText = (card: Card, textLower: string): boolean => {
     return true;
   }
 
-  // タグでの検索（文字列と配列の両方に対応）
+  // タグでの検索
   if (card.tags) {
-    if (Array.isArray(card.tags)) {
-      // タグが配列の場合
-      return card.tags.some((tag: string) =>
-        tag.toLowerCase().includes(textLower)
-      );
-    } else if (typeof card.tags === "string") {
-      // タグが文字列の場合
-      return (card.tags as string).toLowerCase().includes(textLower);
-    }
+    return card.tags.some((tag: string) =>
+      tag.toLowerCase().includes(textLower)
+    );
   }
 
   return false;
@@ -38,27 +31,6 @@ export const isCardMatchingType = (
 ): boolean => {
   const cardTypes = Array.isArray(card.type) ? card.type : [card.type];
   return cardTypes.some((type: CardType) => typeSet.has(type));
-};
-
-/**
- * カードがタイプフィルター（文字列）にマッチするかチェック
- */
-export const isCardMatchingTypeString = (
-  card: Card,
-  typeSet: Set<string>
-): boolean => {
-  const cardTypes = Array.isArray(card.type) ? card.type : [card.type];
-  return cardTypes.some((type: CardType) => {
-    const typeString = getTypeString(type);
-    return typeSet.has(typeString);
-  });
-};
-
-/**
- * CardTypeから文字列表現を取得するヘルパー関数
- */
-const getTypeString = (cardType: CardType): string => {
-  return cardType.value;
 };
 
 /**
@@ -78,43 +50,4 @@ export const isCardMatchingTag = (card: Card, tagSet: Set<string>): boolean => {
   }
 
   return false;
-};
-
-/**
- * カードフィルター関数
- */
-export const createCardFilter = (): ((
-  cards: readonly Card[],
-  criteria: FilterCriteria
-) => Card[]) => {
-  return (cards: readonly Card[], criteria: FilterCriteria): Card[] => {
-    const textLower = criteria.text.toLowerCase();
-    const kindSet = new Set(criteria.kind);
-    const typeSet = new Set(criteria.type);
-    const tagSet = new Set(criteria.tags);
-
-    return cards.filter((card: Card) => {
-      // テキスト検索
-      if (textLower && !isCardMatchingText(card, textLower)) {
-        return false;
-      }
-
-      // 種類フィルター
-      if (kindSet.size > 0 && !kindSet.has(card.kind.type)) {
-        return false;
-      }
-
-      // タイプフィルター
-      if (typeSet.size > 0 && !isCardMatchingTypeString(card, typeSet)) {
-        return false;
-      }
-
-      // タグフィルター
-      if (tagSet.size > 0 && !isCardMatchingTag(card, tagSet)) {
-        return false;
-      }
-
-      return true;
-    });
-  };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - カードの長押し時、デッキに未追加の場合は追加し、既に存在する場合は枚数を増やす動作に変更されました。

- **バグ修正**
  - カードのタグ入力時、空白除去や重複タグのバリデーションが追加されました。

- **機能変更**
  - デッキの最大枚数制限が撤廃され、上限を気にせずカードを追加できるようになりました。
  - デッキ枚数横のバリデーションエラー表示が削除されました。
  - カードフィルター機能の一部が簡素化され、文字列による型フィルタリングや複合条件によるフィルタリングが削除されました。
  - 画像キャッシュの旧管理機能が削除され、キャッシュ操作の互換レイヤーがなくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->